### PR TITLE
Do not zoom on default image

### DIFF
--- a/client/html/themes/aimeos-detail.js
+++ b/client/html/themes/aimeos-detail.js
@@ -96,6 +96,11 @@ AimeosCatalogDetail = {
 	 */
 	zoomImage: function(item, container) {
 
+		// No zoom if there is no image
+		if( item.length === 0 ) {
+			return;
+		}
+
 		// No zoom on small mobile devices
 		if( item.offset().left + item.outerWidth() + container.width() + 10 > $(window).width() ) {
 			return;


### PR DESCRIPTION
Having the default image lets ``item`` being an empty jQuery object. Calling offset() for the mobile device check leads to a JavaScript error.

Check if there is any kind of image and return if there is nothing.