### PR TITLE
Extends length of attribute code colum for storing URLs

### DIFF
--- a/lib/mshoplib/setup/AttributeExtendCodeLength.php
+++ b/lib/mshoplib/setup/AttributeExtendCodeLength.php
@@ -14,7 +14,7 @@ namespace Aimeos\MW\Setup\Task;
  */
 class AttributeExtendCodeLength extends Base
 {
-	private $sql = 'ALTER TABLE "mshop_attribute" CHANGE "code" "code" VARCHAR(255) NOT NULL';
+	private $sql = 'ALTER TABLE "mshop_attribute" CHANGE "code" "code" VARCHAR(255) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL';
 
 
 	/**

--- a/lib/mshoplib/setup/AttributeExtendCodeLength.php
+++ b/lib/mshoplib/setup/AttributeExtendCodeLength.php
@@ -1,0 +1,61 @@
+<?php
+
+/**
+ * @license LGPLv3, http://opensource.org/licenses/LGPL-3.0
+ * @copyright Aimeos (aimeos.org), 2015
+ */
+
+
+namespace Aimeos\MW\Setup\Task;
+
+
+/**
+ * Extends the length of the attribute code column
+ */
+class AttributeExtendCodeLength extends Base
+{
+	private $sql = 'ALTER TABLE "mshop_attribute" CHANGE "code" "code" VARCHAR(255) NOT NULL';
+
+
+	/**
+	 * Returns the list of task names which this task depends on.
+	 *
+	 * @return array List of task names
+	 */
+	public function getPreDependencies()
+	{
+		return array( 'ColumnCodeCollateToUtf8Bin' );
+	}
+
+
+	/**
+	 * Returns the list of task names which depends on this task.
+	 *
+	 * @return string[] List of task names
+	 */
+	public function getPostDependencies()
+	{
+		return array( 'TablesCreateMShop' );
+	}
+
+
+	/**
+	 * Executes the task for MySQL databases.
+	 */
+	protected function mysql()
+	{
+		$this->msg( 'Extend length of attribute code', 0 ); $this->status( '' );
+
+		if( $this->schema->tableExists( 'mshop_attribute' ) === true
+			&& $this->schema->columnExists( 'mshop_attribute', 'code' ) === true
+			&& $this->schema->getColumnDetails( 'mshop_attribute', 'code' )->getMaxLength() < 255
+		) {
+			$this->execute( $this->sql );
+			$this->status( 'done' );
+		}
+		else
+		{
+			$this->status( 'OK' );
+		}
+	}
+}

--- a/lib/mshoplib/src/MShop/Attribute/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Attribute/Item/Standard.php
@@ -135,7 +135,9 @@ class Standard
 	 */
 	public function setCode( $code )
 	{
-		$this->checkCode( $code );
+		if( strlen( $code ) > 255 ) {
+			throw new \Aimeos\MShop\Attribute\Exception( sprintf( 'Code must not be longer than 255 characters' ) );
+		}
 
 		if( $code == $this->getCode() ) { return; }
 


### PR DESCRIPTION
URLs for product downloads are often longer than 32 chars. This should be back ported to 2015.10 too.