### PR TITLE
Prevents loosing properties in the base class that have the same name

### DIFF
--- a/lib/mshoplib/src/MShop/Price/Manager/Base.php
+++ b/lib/mshoplib/src/MShop/Price/Manager/Base.php
@@ -66,6 +66,6 @@ abstract class Base
 			}
 		}
 
-		return clone $price;
+		return $price;
 	}
 }


### PR DESCRIPTION
Seems like a PHP __clone() bug. Occurs in 5.5 but only with Aimeos. A test class hasn't shown the same behavior.