### PR TITLE
Add product code to the order email, summary page.

### DIFF
--- a/client/html/templates/common/summary/detail-body-default.php
+++ b/client/html/templates/common/summary/detail-body-default.php
@@ -201,6 +201,20 @@ $backParams = $this->get( 'summaryParams', array() );
 						<a class="product-name" href="<?php echo $enc->attr( $this->url( $detailTarget, $detailController, $detailAction, $params, array(), $detailConfig ) ); ?>">
 <?php		echo $enc->html( $product->getName(), $enc::TRUST ); ?>
 						</a>
+
+						<p class="code">
+							<span class="name">
+<?php
+								echo $enc->html( $this->translate('client', 'Product code:'), $enc::TRUST);
+?>
+							</span>
+							<span class="value">
+<?php
+								echo $product->getProductCode();
+								//var_dump($product);
+?>
+							</span>
+						</p>
 <?php		foreach( $attrTypes as $attrType ) : ?>
 						<ul class="attr-list <?php echo $enc->attr( 'attr-list-' . $attrType ); ?>">
 <?php			foreach( $product->getAttributes( $attrType ) as $attribute ) : ?>

--- a/client/html/templates/email/common/text-summary-detail-body-default.php
+++ b/client/html/templates/email/common/text-summary-detail-body-default.php
@@ -73,6 +73,7 @@ $unhide = $this->get( 'summaryShowDownloadAttributes', false );
 <?php	$price = $product->getPrice(); ?>
 
 <?php echo strip_tags( $product->getName() ); ?>
+<?php echo $product->getProductCode(); ?>
 
 <?php	foreach( array_merge( $product->getAttributes( 'config' ), $product->getAttributes( 'custom' ) ) as $attribute ) : ?>
 - <?php 	echo strip_tags( $this->translate( 'client/code', $attribute->getCode() ) ); ?>: <?php echo strip_tags( ( $attribute->getName() != '' ? $attribute->getName() : $attribute->getValue() ) ); ?>


### PR DESCRIPTION
A customer may want to know on checkout which articles are which product code, especially useful after selection products have been sorted out and added to the basket.

--

The product code may be required for internal purposes of company.
If the order email is sent as a blind carbon copy to the company then the product codes are required.

Of course alternatively the company could login to e.g. the TYPO3 backend or comparable and have a look at the orders directly.

There may be companies that prefer mail.
