### PR TITLE
Preserve png alpha channel

### DIFF
--- a/lib/mwlib/src/MW/Media/Image/Standard.php
+++ b/lib/mwlib/src/MW/Media/Image/Standard.php
@@ -105,6 +105,9 @@ class Standard
 					$quality = (int) $this->options['image']['png']['quality'];
 				}
 
+				imagealphablending($this->image, FALSE);
+				imagesavealpha($this->image, TRUE);
+				
 				if( @imagepng( $this->image, $filename, $quality ) === false ) {
 					throw new \Aimeos\MW\Media\Exception( sprintf( 'Unable to save image to file "%1$s"', $filename ) );
 				}

--- a/lib/mwlib/src/MW/Media/Image/Standard.php
+++ b/lib/mwlib/src/MW/Media/Image/Standard.php
@@ -105,11 +105,11 @@ class Standard
 					$quality = (int) $this->options['image']['png']['quality'];
 				}
 
-				if( @imagealphablending($this->image, FALSE) === false ){
+				if( @imagealphablending($this->image, false) === false ){
 					throw new \Aimeos\MW\Media\Exception( sprintf( 'There was an error during the png processing in gdlib (alphablending)') );
 				}
 
-				if( @imagesavealpha($this->image, TRUE) === false ){
+				if( @imagesavealpha($this->image, true) === false ){
 					throw new \Aimeos\MW\Media\Exception( sprintf( 'There was an error during the png processing in gdlib(imagesavealpha)') );
 				}
 				

--- a/lib/mwlib/src/MW/Media/Image/Standard.php
+++ b/lib/mwlib/src/MW/Media/Image/Standard.php
@@ -105,8 +105,13 @@ class Standard
 					$quality = (int) $this->options['image']['png']['quality'];
 				}
 
-				imagealphablending($this->image, false);
-				imagesavealpha($this->image, true);
+				if( @imagealphablending($this->image, FALSE) === false ){
+					throw new \Aimeos\MW\Media\Exception( sprintf( 'There was an error during the png processing in gdlib (alphablending)') );
+				}
+
+				if( @imagesavealpha($this->image, TRUE) === false ){
+					throw new \Aimeos\MW\Media\Exception( sprintf( 'There was an error during the png processing in gdlib(imagesavealpha)') );
+				}
 				
 				if( @imagepng( $this->image, $filename, $quality ) === false ) {
 					throw new \Aimeos\MW\Media\Exception( sprintf( 'Unable to save image to file "%1$s"', $filename ) );

--- a/lib/mwlib/src/MW/Media/Image/Standard.php
+++ b/lib/mwlib/src/MW/Media/Image/Standard.php
@@ -105,8 +105,8 @@ class Standard
 					$quality = (int) $this->options['image']['png']['quality'];
 				}
 
-				imagealphablending($this->image, FALSE);
-				imagesavealpha($this->image, TRUE);
+				imagealphablending($this->image, false);
+				imagesavealpha($this->image, true);
 				
 				if( @imagepng( $this->image, $filename, $quality ) === false ) {
 					throw new \Aimeos\MW\Media\Exception( sprintf( 'Unable to save image to file "%1$s"', $filename ) );


### PR DESCRIPTION
Those two lines preserve the alpha channel for png's. For now opaque regions are black after saving a file.