### PR TITLE
Bug fix on stock

### DIFF
--- a/controller/common/src/Controller/Common/Order/Standard.php
+++ b/controller/common/src/Controller/Common/Order/Standard.php
@@ -440,6 +440,10 @@ class Standard
 			}
 		}
 
+		if( $sum === null ) {
+			return;
+		}
+
 		if( $selStockItem === null )
 		{
 			$typeManager = \Aimeos\MShop\Factory::createManager( $this->context, 'stock/type' );

--- a/controller/common/src/Controller/Common/Order/Standard.php
+++ b/controller/common/src/Controller/Common/Order/Standard.php
@@ -434,14 +434,10 @@ class Standard
 			$stock = $stockItem->getStockLevel();
 
 			if( $stock === null ) {
-				$sum = null;
+				return;
 			} elseif( $sum !== null && $stock > 0 ) {
 				$sum += $stock;
 			}
-		}
-
-		if( $sum === null ) {
-			return;
 		}
 
 		if( $selStockItem === null )


### PR DESCRIPTION
We found a bug this night on selections if stock of the product is set to null. Here the exception:

Executing statement "
			INSERT INTO "mshop_stock" (
				"productcode", "siteid", "typeid", "stocklevel", "backdate",
				"mtime", "editor", "ctime"
			) VALUES (
				'fb-b-einfach', 1, 1, NULL, NULL, '2017-02-15 00:05:28', '', '2017-02-15 00:05:28'
			)
		" failed: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '1-fb-b-einfach-1' for key 'unq_mssto_sid_pcode_tid'
#0 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Libraries/aimeos/aimeos-core/lib/mshoplib/src/MShop/Stock/Manager/Standard.php(258): Aimeos\MW\DB\Statement\PDO\Simple->execute()
#1 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Libraries/aimeos/aimeos-core/lib/mshoplib/src/MShop/Common/Manager/Decorator/Base.php(187): Aimeos\MShop\Stock\Manager\Standard->saveItem(Object(Aimeos\MShop\Stock\Item\Standard), false)
#2 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Libraries/aimeos/aimeos-core/lib/mshoplib/src/MShop/Common/Manager/Decorator/Sitecheck.php(42): Aimeos\MShop\Common\Manager\Decorator\Base->saveItem(Object(Aimeos\MShop\Stock\Item\Standard), false)
#3 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Libraries/aimeos/aimeos-core/controller/common/src/Controller/Common/Order/Standard.php(454): Aimeos\MShop\Common\Manager\Decorator\Sitecheck->saveItem(Object(Aimeos\MShop\Stock\Item\Standard), false)
#4 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Libraries/aimeos/aimeos-core/controller/common/src/Controller/Common/Order/Standard.php(340): Aimeos\Controller\Common\Order\Standard->updateStockSelection('352', 'default')
#5 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Libraries/aimeos/aimeos-core/controller/common/src/Controller/Common/Order/Standard.php(298): Aimeos\Controller\Common\Order\Standard->updateStock(Object(Aimeos\MShop\Order\Item\Standard), -1)
#6 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Libraries/aimeos/aimeos-core/controller/common/src/Controller/Common/Order/Standard.php(58): Aimeos\Controller\Common\Order\Standard->updateStatus(Object(Aimeos\MShop\Order\Item\Standard), 'stock-update', 1, -1)
#7 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Private/Extensions/ai-controller-frontend/controller/frontend/src/Controller/Frontend/Order/Standard.php(77): Aimeos\Controller\Common\Order\Standard->block(Object(Aimeos\MShop\Order\Item\Standard))
#8 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Private/Extensions/ai-client-html/client/html/src/Client/Html/Checkout/Standard/Order/Standard.php(273): Aimeos\Controller\Frontend\Order\Standard->block(Object(Aimeos\MShop\Order\Item\Standard))
#9 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Private/Extensions/ai-client-html/client/html/src/Client/Html/Base.php(150): Aimeos\Client\Html\Checkout\Standard\Order\Standard->process()
#10 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Resources/Private/Extensions/ai-client-html/client/html/src/Client/Html/Checkout/Standard/Standard.php(354): Aimeos\Client\Html\Base->process()
#11 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Classes/Controller/AbstractController.php(167): Aimeos\Client\Html\Checkout\Standard\Standard->process()
#12 /var/www/clients/client15/web7/web/typo3conf/ext/aimeos/Classes/Controller/CheckoutController.php(32): Aimeos\Aimeos\Controller\AbstractController->getClientOutput(Object(Aimeos\Client\Html\Checkout\Standard\Standard))
#13 [internal function]: Aimeos\Aimeos\Controller\CheckoutController->indexAction()
