### PR TITLE
Update ServicesUpdate.php

### DIFF
--- a/lib/mshoplib/src/MShop/Plugin/Provider/Order/ServicesUpdate.php
+++ b/lib/mshoplib/src/MShop/Plugin/Provider/Order/ServicesUpdate.php
@@ -41,6 +41,7 @@ class ServicesUpdate
 		$p->addListener( $this->getObject(), 'setAddress.after' );
 		$p->addListener( $this->getObject(), 'deleteAddress.after' );
 		$p->addListener( $this->getObject(), 'addProduct.after' );
+		$p->addListener( $this->getObject(), 'editProduct.after' );
 		$p->addListener( $this->getObject(), 'deleteProduct.after' );
 		$p->addListener( $this->getObject(), 'addCoupon.after' );
 		$p->addListener( $this->getObject(), 'deleteCoupon.after' );


### PR DESCRIPTION
Could you add this listener, please? Otherwise, the delivery costs are not immediately updated, if you change the quantity of products. At least in our shop scenario this was the case and adding the listener by $p->addListener( $this->getObject(), 'editProduct.after' ); was the solution. https://aimeos.org/help/help-f15/shipping-costs-depending-on-basket-weight-t1074.html is related to this problem. Thank you!