### PR TITLE
Ignore non-existing directories

### DIFF
--- a/Bootstrap.php
+++ b/Bootstrap.php
@@ -276,6 +276,10 @@ class Bootstrap
 
 		foreach( $directories as $directory )
 		{
+			if (!file_exists($directory)) {
+				continue;
+			}
+
 			$manifest = $this->getManifestFile( $directory );
 
 			if( $manifest !== false )


### PR DESCRIPTION
Exception 

DirectoryIterator::__construct([...]/typo3conf/ext/aimeos/Resources/Private/Extensions/,[...]/typo3conf/ext/aimeos/Resources/Private/Extensions/): Das System kann die angegebene Datei nicht finden. (code: 2) 

is thrown if directory does not exists.