### PR TITLE
Always index lowest price

### DIFF
--- a/lib/mshoplib/src/MShop/Index/Manager/Price/Standard.php
+++ b/lib/mshoplib/src/MShop/Index/Manager/Price/Standard.php
@@ -668,7 +668,11 @@ class Standard
 
 		foreach( $item->getListItems( 'price', 'default', $types ) as $listItem )
 		{
-			if( ( $refItem = $listItem->getRefItem() ) !== null && $refItem->isAvailable() ) {
+ 			if( ( $refItem = $listItem->getRefItem() ) !== null 
+				&& $refItem->isAvailable() 
+				&& ( !isset ( $prices[$refItem->getCurrencyId()][$refItem->getQuantity()] ) 
+				|| $prices[$refItem->getCurrencyId()][$refItem->getQuantity()] > $refItem->getValue() )
+			) {
 				$prices[$refItem->getCurrencyId()][$refItem->getQuantity()] = $refItem->getValue();
 			}
 		}

--- a/lib/mshoplib/src/MShop/Index/Manager/Price/Standard.php
+++ b/lib/mshoplib/src/MShop/Index/Manager/Price/Standard.php
@@ -654,26 +654,30 @@ class Standard
 		$siteid = $context->getLocale()->getSiteId();
 
 		/** mshop/index/manager/price/types
-		 * Use different product prices types for sorting by price
+		 * Use different product prices types for indexing
 		 *
 		 * In some cases, prices are stored with different types, eg. price per kg.
-		 * This configuration option defines which types are incorporated when sorting
-		 * the product list by price.
+		 * This configuration option defines which types are incorporated in which
+		 * order. If a price of the defined type with the lowest index is available,
+		 * it will be indexed, otherwise the next lowest index price type. It is
+		 * highly recommended to add the price type 'default' with the highest index.
 		 *
 		 * @param array List of price types codes
 		 * @since 2019.04
 		 * @category Developer
 		 */
-		$types = $context->getConfig()->get( 'mshop/index/manager/price/types', 'default' );
+		$types = $context->getConfig()->get( 'mshop/index/manager/price/types', ['default'] );
 
-		foreach( $item->getListItems( 'price', 'default', $types ) as $listItem )
+		foreach( $types as $priceType )
 		{
- 			if( ( $refItem = $listItem->getRefItem() ) !== null 
-				&& $refItem->isAvailable() 
-				&& ( !isset ( $prices[$refItem->getCurrencyId()][$refItem->getQuantity()] ) 
-				|| $prices[$refItem->getCurrencyId()][$refItem->getQuantity()] > $refItem->getValue() )
-			) {
-				$prices[$refItem->getCurrencyId()][$refItem->getQuantity()] = $refItem->getValue();
+			foreach( $item->getListItems( 'price', 'default', $priceType ) as $listItem )
+			{
+				if( ( $refItem = $listItem->getRefItem() ) !== null
+					&& $refItem->isAvailable()
+					&& !isset ( $prices[$refItem->getCurrencyId()][$refItem->getQuantity()] )
+				) {
+					$prices[$refItem->getCurrencyId()][$refItem->getQuantity()] = $refItem->getValue();
+				}
 			}
 		}
 


### PR DESCRIPTION
Sorry I have to bring up this topic again, but currenty the 2019.x branch behaves different than the 2018.10 branch.

When indexing prices, the lowest price should be indexed, to mimic 2018.x's behaviour. This is important in certain use cases, see my last comment in the original PR #140. 