### PR TITLE
Use actual quality when setting imagick quality

### DIFF
--- a/lib/mwlib/src/MW/Media/Image/Imagick.php
+++ b/lib/mwlib/src/MW/Media/Image/Imagick.php
@@ -75,7 +75,7 @@ class Imagick
 		try
 		{
 			$this->image->setImageFormat( $mime[1] );
-			$this->image->setImageCompressionQuality( 100 - $quality ); // inverse quality scheme
+			$this->image->setImageCompressionQuality( $quality );
 
 			if( $filename === null ) {
 				return $this->image->getImageBlob();


### PR DESCRIPTION
The inverse of the quality is no longer required with \Imagick::setImageCompressionQuality.