### PR TITLE
Fix MySql Compatibility check with MariaDB

### DIFF
--- a/lib/mshoplib/setup/TablesUpdateCharsetCollation.php
+++ b/lib/mshoplib/setup/TablesUpdateCharsetCollation.php
@@ -205,7 +205,7 @@ class TablesUpdateCharsetCollation extends \Aimeos\MW\Setup\Task\Base
 		// MariaDB gets identified as a MySql 5.5.5 by doctrine so ask the server directly
 		$version = $this->getValue( 'SELECT version() AS "version"', 'version', $rname );
 
-		if ( strpos( $version, 'MariaDB' ) !== false) {
+		if ( strpos( $version, 'MariaDB' ) !== false ) {
 			return version_compare( $version, '10.2.7', '>=' );
 		}
 

--- a/lib/mshoplib/setup/TablesUpdateCharsetCollation.php
+++ b/lib/mshoplib/setup/TablesUpdateCharsetCollation.php
@@ -205,12 +205,10 @@ class TablesUpdateCharsetCollation extends \Aimeos\MW\Setup\Task\Base
 		// MariaDB gets identified as a MySql 5.5.5 by doctrine so ask the server directly
 		$version = $this->getValue( 'SELECT version() AS "version"', 'version', $rname );
 
-		if( ( strpos( $version, 'MariaDB' ) !== false && version_compare( $version, '10.2.7', '>=' ) )
-			|| version_compare( $version, '5.7.7', '>=' )
-		) {
-			return true;
+		if ( strpos( $version, 'MariaDB' ) !== false) {
+			return version_compare( $version, '10.2.7', '>=' );
 		}
 
-		return false;
+		return version_compare( $version, '5.7.7', '>=' );
 	}
 }


### PR DESCRIPTION
The old code would compare the version against 5.7.7 even for MariaDB.