### PR TITLE
fix check for status < 0 in availability and test it

### DIFF
--- a/lib/mshoplib/src/MShop/Attribute/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Attribute/Item/Standard.php
@@ -293,7 +293,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Catalog/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Catalog/Item/Standard.php
@@ -395,7 +395,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return (bool) $this->getStatus();
+		return $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Common/Item/Lists/Standard.php
+++ b/lib/mshoplib/src/MShop/Common/Item/Lists/Standard.php
@@ -398,7 +398,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus()
+		return parent::isAvailable() && $this->getStatus() > 0
 			&& ( $this->getDateStart() === null || $this->getDateStart() < $this->values['date'] )
 			&& ( $this->getDateEnd() === null || $this->getDateEnd() > $this->values['date'] );
 	}

--- a/lib/mshoplib/src/MShop/Common/Item/Type/Standard.php
+++ b/lib/mshoplib/src/MShop/Common/Item/Type/Standard.php
@@ -238,7 +238,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Coupon/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Coupon/Item/Standard.php
@@ -253,7 +253,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus()
+		return parent::isAvailable() && $this->getStatus() > 0
 			&& ( $this->getDateStart() === null || $this->getDateStart() < $this->values['date'] )
 			&& ( $this->getDateEnd() === null || $this->getDateEnd() > $this->values['date'] );
 	}

--- a/lib/mshoplib/src/MShop/Customer/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Customer/Item/Standard.php
@@ -308,7 +308,7 @@ class Standard extends Base implements Iface
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Locale/Item/Currency/Standard.php
+++ b/lib/mshoplib/src/MShop/Locale/Item/Currency/Standard.php
@@ -203,7 +203,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Locale/Item/Language/Standard.php
+++ b/lib/mshoplib/src/MShop/Locale/Item/Language/Standard.php
@@ -208,7 +208,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Locale/Item/Site/Standard.php
+++ b/lib/mshoplib/src/MShop/Locale/Item/Site/Standard.php
@@ -236,7 +236,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Locale/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Locale/Item/Standard.php
@@ -282,7 +282,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Media/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Media/Item/Standard.php
@@ -367,7 +367,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus()
+		return parent::isAvailable() && $this->getStatus() > 0
 			&& ( $this->values['languageid'] === null
 			|| $this->getLanguageId() === null
 			|| $this->getLanguageId() === $this->values['languageid'] );

--- a/lib/mshoplib/src/MShop/Plugin/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Plugin/Item/Standard.php
@@ -257,7 +257,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Price/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Price/Item/Standard.php
@@ -462,7 +462,7 @@ class Standard extends Base
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus()
+		return parent::isAvailable() && $this->getStatus() > 0
 			&& ( $this->values['currencyid'] === null || $this->getCurrencyId() === $this->values['currencyid'] );
 	}
 

--- a/lib/mshoplib/src/MShop/Product/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Product/Item/Standard.php
@@ -370,7 +370,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus()
+		return parent::isAvailable() && $this->getStatus() > 0
 			&& ( $this->getDateStart() === null || $this->getDateStart() < $this->values['date'] )
 			&& ( $this->getDateEnd() === null || $this->getDateEnd() > $this->values['date'] );
 	}

--- a/lib/mshoplib/src/MShop/Service/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Service/Item/Standard.php
@@ -355,7 +355,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus()
+		return parent::isAvailable() && $this->getStatus() > 0
 			&& ( $this->getDateStart() === null || $this->getDateStart() < $this->values['date'] )
 			&& ( $this->getDateEnd() === null || $this->getDateEnd() > $this->values['date'] );
 	}

--- a/lib/mshoplib/src/MShop/Supplier/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Supplier/Item/Standard.php
@@ -179,7 +179,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus();
+		return parent::isAvailable() && $this->getStatus() > 0;
 	}
 
 

--- a/lib/mshoplib/src/MShop/Text/Item/Standard.php
+++ b/lib/mshoplib/src/MShop/Text/Item/Standard.php
@@ -258,7 +258,7 @@ class Standard
 	 */
 	public function isAvailable()
 	{
-		return parent::isAvailable() && (bool) $this->getStatus()
+		return parent::isAvailable() && $this->getStatus() > 0
 			&& ( $this->values['languageid'] === null
 			|| $this->getLanguageId() === null
 			|| $this->getLanguageId() === $this->values['languageid'] );

--- a/lib/mshoplib/tests/MShop/Attribute/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Attribute/Item/StandardTest.php
@@ -248,6 +248,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Catalog/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Catalog/Item/StandardTest.php
@@ -202,6 +202,16 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	}
 
 
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
 	public function testIsModified()
 	{
 		$this->assertFalse( $this->object->isModified() );

--- a/lib/mshoplib/tests/MShop/Common/Item/Lists/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Common/Item/Lists/StandardTest.php
@@ -24,7 +24,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 			'common.lists.domain' => 'testDomain',
 			'common.lists.refid' => 'unitId',
 			'common.lists.datestart' => '2005-01-01 00:00:00',
-			'common.lists.dateend' => '2010-12-31 00:00:00',
+			'common.lists.dateend' => '2100-01-01 00:00:00',
 			'common.lists.config' => array( 'cnt' => '40' ),
 			'common.lists.position' => 7,
 			'common.lists.status' => 1,
@@ -136,7 +136,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetDateEnd()
 	{
-		$this->assertEquals( '2010-12-31 00:00:00', $this->object->getDateEnd() );
+		$this->assertEquals( '2100-01-01 00:00:00', $this->object->getDateEnd() );
 	}
 
 
@@ -249,6 +249,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 	public function testIsAvailable()
 	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
 		$this->assertFalse( $this->object->isAvailable() );
 	}
 
@@ -323,7 +335,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 			'common.lists.domain' => 'testDomain',
 			'common.lists.refid' => 'unitId',
 			'common.lists.datestart' => '2005-01-01 00:00:00',
-			'common.lists.dateend' => '2010-12-31 00:00:00',
+			'common.lists.dateend' => '2100-01-01 00:00:00',
 			'common.lists.config' => array( 'cnt' => '40' ),
 			'common.lists.position' => 7,
 			'common.lists.status' => 1,

--- a/lib/mshoplib/tests/MShop/Common/Item/Type/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Common/Item/Type/StandardTest.php
@@ -207,6 +207,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Coupon/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Coupon/Item/StandardTest.php
@@ -232,6 +232,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Customer/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Customer/Item/StandardTest.php
@@ -411,6 +411,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Locale/Item/Currency/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Locale/Item/Currency/StandardTest.php
@@ -197,6 +197,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 }

--- a/lib/mshoplib/tests/MShop/Locale/Item/Language/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Locale/Item/Language/StandardTest.php
@@ -216,6 +216,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 }

--- a/lib/mshoplib/tests/MShop/Locale/Item/Site/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Locale/Item/Site/StandardTest.php
@@ -171,6 +171,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Locale/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Locale/Item/StandardTest.php
@@ -259,6 +259,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 }

--- a/lib/mshoplib/tests/MShop/Media/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Media/Item/StandardTest.php
@@ -308,6 +308,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 }

--- a/lib/mshoplib/tests/MShop/Plugin/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Plugin/Item/StandardTest.php
@@ -245,5 +245,17 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 }

--- a/lib/mshoplib/tests/MShop/Price/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Price/Item/StandardTest.php
@@ -466,6 +466,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Product/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Product/Item/StandardTest.php
@@ -22,7 +22,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 			'product.id' => 1,
 			'product.siteid' => 99,
 			'product.type' => 'test',
-			'product.status' => 0,
+			'product.status' => 1,
 			'product.code' => 'TEST',
 			'product.label' => 'testproduct',
 			'product.config' => array( 'css-class' => 'test' ),
@@ -172,7 +172,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetStatus()
 	{
-		$this->assertEquals( 0, $this->object->getStatus() );
+		$this->assertEquals( 1, $this->object->getStatus() );
 	}
 
 
@@ -300,6 +300,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 	public function testIsAvailable()
 	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
 		$this->assertFalse( $this->object->isAvailable() );
 	}
 

--- a/lib/mshoplib/tests/MShop/Service/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Service/Item/StandardTest.php
@@ -28,7 +28,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 			'service.datestart' => '2000-01-01 00:00:00',
 			'service.dateend' => '2100-01-01 00:00:00',
 			'service.config' => array( 'url' => 'https://localhost/' ),
-			'service.status' => 0,
+			'service.status' => 1,
 			'service.mtime' => '2011-01-01 00:00:02',
 			'service.ctime' => '2011-01-01 00:00:01',
 			'service.editor' => 'unitTestUser'
@@ -171,7 +171,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetStatus()
 	{
-		$this->assertEquals( 0, $this->object->getStatus() );
+		$this->assertEquals( 1, $this->object->getStatus() );
 	}
 
 
@@ -300,6 +300,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 	public function testIsAvailable()
 	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
 		$this->assertFalse( $this->object->isAvailable() );
 	}
 }

--- a/lib/mshoplib/tests/MShop/Service/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Service/Item/StandardTest.php
@@ -280,7 +280,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	{
 		$arrayObject = $this->object->toArray( true );
 
-		$this->assertEquals( count( $this->values ), count( $arrayObject ) );
+		$this->assertEquals( count( $this->values ) - 1, count( $arrayObject ) );
 
 		$this->assertEquals( $this->object->getId(), $arrayObject['service.id'] );
 		$this->assertEquals( $this->object->getSiteId(), $arrayObject['service.siteid'] );

--- a/lib/mshoplib/tests/MShop/Service/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Service/Item/StandardTest.php
@@ -31,7 +31,8 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 			'service.status' => 1,
 			'service.mtime' => '2011-01-01 00:00:02',
 			'service.ctime' => '2011-01-01 00:00:01',
-			'service.editor' => 'unitTestUser'
+			'service.editor' => 'unitTestUser',
+			'date' => date( 'Y-m-d H:i:s' ),
 		);
 
 		$this->object = new \Aimeos\MShop\Service\Item\Standard( $this->values );

--- a/lib/mshoplib/tests/MShop/Supplier/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Supplier/Item/StandardTest.php
@@ -136,6 +136,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Text/Item/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Text/Item/StandardTest.php
@@ -263,5 +263,17 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 	public function testIsAvailable()
 	{
 		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setAvailable( false );
+		$this->assertFalse( $this->object->isAvailable() );
+	}
+
+
+	public function testIsAvailableOnStatus()
+	{
+		$this->assertTrue( $this->object->isAvailable() );
+		$this->object->setStatus( 0 );
+		$this->assertFalse( $this->object->isAvailable() );
+		$this->object->setStatus( -1 );
+		$this->assertFalse( $this->object->isAvailable() );
 	}
 }


### PR DESCRIPTION
I added some test cases to check `parent::isAvailable` is called and the status is actually checked and working as intended. Most items could still use more checks based on language, end/start date or other factors.