### PR TITLE
Scale method option for preview images

### DIFF
--- a/controller/common/src/Controller/Common/Media/Standard.php
+++ b/controller/common/src/Controller/Common/Media/Standard.php
@@ -469,7 +469,31 @@ class Standard
 		 * @category User
 		 */
 		$maxheight = $config->get( 'controller/common/media/standard/' . $type . '/maxheight', null );
+		
+		/** controller/common/media/standard/preview/scalemode
+		 * Scale mode of the preview images
+		 *
+		 * The preview image files can either be scaled or cropped. If scaled,
+		 * the width/height ratio will be maintained in the thumbnail image.
+		 * If cropped, the image will be scaled so that max width and max height
+		 * are matched and cropped to the desired (max) width/height afterwards.
+		 * This is useful e.g. for square thumbnail pictures with maximum quality
+		 * and minimum file size.
+		 *
+		 * Only available with Imagick algorithm implementation. Needs values for
+		 * max height and width.
+		 *
+		 * @param string Scale mode, either "scale" or "crop"
+		 * @since 2018.10
+		 * @category Developer
+		 * @category User
+		 */
+		$scalemode = $config->get( 'controller/common/media/standard/' . $type . '/scalemode', null );
 
+		if( $scalemode && $scalemode == 'crop' && method_exists( $media, 'cropscale' ) && $maxheight && $maxwidth ) {
+			return $media->cropscale( $maxwidth, $maxheight );
+		}
+		
 		if( $maxheight || $maxwidth ) {
 			return $media->scale( $maxwidth, $maxheight );
 		}

--- a/controller/common/src/Controller/Common/Media/Standard.php
+++ b/controller/common/src/Controller/Common/Media/Standard.php
@@ -470,32 +470,41 @@ class Standard
 		 */
 		$maxheight = $config->get( 'controller/common/media/standard/' . $type . '/maxheight', null );
 		
-		/** controller/common/media/standard/preview/scalemode
-		 * Scale mode of the preview images
+		/** controller/common/media/standard/files/force-size
+		 * Force exact image size for the uploaded images
 		 *
-		 * The preview image files can either be scaled or cropped. If scaled,
-		 * the width/height ratio will be maintained in the thumbnail image.
-		 * If cropped, the image will be scaled so that max width and max height
-		 * are matched and cropped to the desired (max) width/height afterwards.
-		 * This is useful e.g. for square thumbnail pictures with maximum quality
-		 * and minimum file size.
+		 * This configuration forces the output image to have exact the width
+		 * and height specified in maxwidth / maxheight configuration options.
 		 *
-		 * Only available with Imagick algorithm implementation. Needs values for
-		 * max height and width.
+		 * With Imagick algorithm implementation, the image will be cropped with
+		 * center gravity, in the default implementation the image will be
+		 * stretched.
 		 *
-		 * @param string Scale mode, either "scale" or "crop"
+		 * @param integer Zero to disable the feature, one to enable it
 		 * @since 2018.10
 		 * @category Developer
 		 * @category User
 		 */
-		$scalemode = $config->get( 'controller/common/media/standard/' . $type . '/scalemode', null );
-
-		if( $scalemode && $scalemode == 'crop' && method_exists( $media, 'cropscale' ) && $maxheight && $maxwidth ) {
-			return $media->cropscale( $maxwidth, $maxheight );
-		}
 		
+		/** controller/common/media/standard/preview/force-size
+		 * Force exact image size for the preview images
+		 *
+		 * This configuration forces the output image to have exact the width
+		 * and height specified in maxwidth / maxheight configuration options.
+		 *
+		 * With Imagick algorithm implementation, the image will be cropped with
+		 * center gravity, in the default implementation the image will be
+		 * stretched.
+		 *
+		 * @param integer Zero to disable the feature, one to enable it
+		 * @since 2018.10
+		 * @category Developer
+		 * @category User
+		 */
+		$fit = $config->get( 'controller/common/media/standard/' . $type . '/force-size', null ) ? false : true;
+
 		if( $maxheight || $maxwidth ) {
-			return $media->scale( $maxwidth, $maxheight );
+			return $media->scale( $maxwidth, $maxheight, $fit );
 		}
 
 		return $media;

--- a/lib/mwlib/src/MW/Media/Image/Imagick.php
+++ b/lib/mwlib/src/MW/Media/Image/Imagick.php
@@ -120,4 +120,22 @@ class Imagick
 
 		return $this;
 	}
+	
+	/**
+	 * Crop-scales the image to the given width and height.
+	 *
+	 * @param integer $width New width of the image
+	 * @param integer $height New height of the image
+	 * @return \Aimeos\MW\Media\Iface Self object for method chaining
+	 */
+	public function cropscale( $width, $height )
+	{
+		try {
+			$this->image->cropThumbnailImage( $width, $height );
+		} catch( \Exception $e ) {
+			throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
+		}
+
+		return $this;
+	}
 }

--- a/lib/mwlib/src/MW/Media/Image/Imagick.php
+++ b/lib/mwlib/src/MW/Media/Image/Imagick.php
@@ -100,28 +100,24 @@ class Imagick
 	 */
 	public function scale( $width, $height, $fit = true )
 	{
-		if( $fit === false && $width && $height ) {
-			try {
+		try {
+			if( $fit === false && $width && $height ) {
 				$this->image->cropThumbnailImage( $width, $height );
 				$this->image->setImagePage(0, 0, 0, 0); // see https://www.php.net/manual/en/imagick.cropthumbnailimage.php#106710
-			} catch( \Exception $e ) {
-				throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
-			}
-		} else {
-			$w = $this->image->getImageWidth();
-			$h = $this->image->getImageHeight();
+			} else {
+				$w = $this->image->getImageWidth();
+				$h = $this->image->getImageHeight();
 
-			list( $width, $height ) = $this->getSizeFitted( $w, $h, $width, $height );
+				list( $width, $height ) = $this->getSizeFitted( $w, $h, $width, $height );
 
-			if( $w <= $width && $h <= $height ) {
-				return $this;
-			}
+				if( $w <= $width && $h <= $height ) {
+					return $this;
+				}
 
-			try {
 				$this->image->resizeImage( $width, $height, \Imagick::FILTER_CUBIC, 0.8 );
-			} catch( \Exception $e ) {
-				throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
 			}
+		} catch( \Exception $e ) {
+			throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
 		}
 
 		return $this;

--- a/lib/mwlib/src/MW/Media/Image/Imagick.php
+++ b/lib/mwlib/src/MW/Media/Image/Imagick.php
@@ -100,23 +100,31 @@ class Imagick
 	 */
 	public function scale( $width, $height, $fit = true )
 	{
-		try {
-			if( $fit === false && $width && $height ) {
-				$this->image->cropThumbnailImage( $width, $height );
-				$this->image->setImagePage(0, 0, 0, 0); // see https://www.php.net/manual/en/imagick.cropthumbnailimage.php#106710
-			} else {
+		try
+		{
+			if( $fit == true )
+			{
 				$w = $this->image->getImageWidth();
 				$h = $this->image->getImageHeight();
-
 				list( $width, $height ) = $this->getSizeFitted( $w, $h, $width, $height );
 
 				if( $w <= $width && $h <= $height ) {
 					return $this;
 				}
-
-				$this->image->resizeImage( $width, $height, \Imagick::FILTER_CUBIC, 0.8 );
 			}
-		} catch( \Exception $e ) {
+			elseif( $width && $height )
+			{
+				$this->image->cropThumbnailImage( $width, $height );
+				// see https://www.php.net/manual/en/imagick.cropthumbnailimage.php#106710
+				$this->image->setImagePage( 0, 0, 0, 0 );
+
+				return $this;
+			}
+
+			$this->image->resizeImage( $width, $height, \Imagick::FILTER_CUBIC, 0.8 );
+		}
+		catch( \Exception $e )
+		{
 			throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
 		}
 

--- a/lib/mwlib/src/MW/Media/Image/Imagick.php
+++ b/lib/mwlib/src/MW/Media/Image/Imagick.php
@@ -100,8 +100,14 @@ class Imagick
 	 */
 	public function scale( $width, $height, $fit = true )
 	{
-		if( $fit === true )
-		{
+		if( $fit === false && $width && $height ) {
+			try {
+				$this->image->cropThumbnailImage( $width, $height );
+				$this->image->setImagePage(0, 0, 0, 0); // see https://www.php.net/manual/en/imagick.cropthumbnailimage.php#106710
+			} catch( \Exception $e ) {
+				throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
+			}
+		} else {
 			$w = $this->image->getImageWidth();
 			$h = $this->image->getImageHeight();
 
@@ -110,30 +116,12 @@ class Imagick
 			if( $w <= $width && $h <= $height ) {
 				return $this;
 			}
-		}
 
-		try {
-			$this->image->resizeImage( $width, $height, \Imagick::FILTER_CUBIC, 0.8 );
-		} catch( \Exception $e ) {
-			throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
-		}
-
-		return $this;
-	}
-	
-	/**
-	 * Crop-scales the image to the given width and height.
-	 *
-	 * @param integer $width New width of the image
-	 * @param integer $height New height of the image
-	 * @return \Aimeos\MW\Media\Iface Self object for method chaining
-	 */
-	public function cropscale( $width, $height )
-	{
-		try {
-			$this->image->cropThumbnailImage( $width, $height );
-		} catch( \Exception $e ) {
-			throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
+			try {
+				$this->image->resizeImage( $width, $height, \Imagick::FILTER_CUBIC, 0.8 );
+			} catch( \Exception $e ) {
+				throw new \Aimeos\MW\Media\Exception( $e->getMessage() );
+			}
 		}
 
 		return $this;


### PR DESCRIPTION
Adds an option for crop thumbnail generation with Imagick. When square thumbnails are used in the product catalog list (e.g. with `background-size: cover` CSS code), unproportinal images cause either very large preview images or very blurry scaled ones. This configuration option adds a possibility to choose between scaling and scale-cropping thumbnails.

No breaking changes, fully backwards compatible, all documented.

What do you think?