### PR TITLE
Handle unavailable coupon codes

### DIFF
--- a/lib/mshoplib/src/MShop/Coupon/Provider/Base.php
+++ b/lib/mshoplib/src/MShop/Coupon/Provider/Base.php
@@ -51,7 +51,7 @@ abstract class Base implements Iface
 		{
 			$base->deleteCoupon( $this->code, true );
 			$msg = $this->getContext()->getI18n()->dt( 'mshop', 'Coupon in basket is not available any more' );
-			throw new \Aimeos\MShop\Plugin\Provider\Exception( $msg, -1, null );
+			throw new \Aimeos\MShop\Plugin\Provider\Exception( $msg );
 		}
 		$this->deleteCoupon( $base );
 		$this->addCoupon( $base );

--- a/lib/mshoplib/src/MShop/Coupon/Provider/Base.php
+++ b/lib/mshoplib/src/MShop/Coupon/Provider/Base.php
@@ -49,10 +49,10 @@ abstract class Base implements Iface
 	{
 		if( $this->getObject()->isAvailable( $base ) !== true )
 		{
-			$base->deleteCoupon( $this->code );
-			return;
+			$base->deleteCoupon( $this->code, true );
+			$msg = $this->getContext()->getI18n()->dt( 'mshop', 'Coupon in basket is not available any more' );
+			throw new \Aimeos\MShop\Plugin\Provider\Exception( $msg, -1, null );
 		}
-
 		$this->deleteCoupon( $base );
 		$this->addCoupon( $base );
 	}

--- a/lib/mshoplib/src/MShop/Plugin/Provider/Order/Coupon.php
+++ b/lib/mshoplib/src/MShop/Plugin/Provider/Order/Coupon.php
@@ -90,7 +90,7 @@ class Coupon
 			}
 			else
 			{
-				$notAvailable[$code] = 'coupon.gone';
+				$notAvailable[$code] = 'gone';
 			}
 		}
 

--- a/lib/mshoplib/src/MShop/Plugin/Provider/Order/Coupon.php
+++ b/lib/mshoplib/src/MShop/Plugin/Provider/Order/Coupon.php
@@ -85,7 +85,7 @@ class Coupon
 				}
 				catch( \Exception $e )
 				{
-					$notAvailable[$code] = 'coupon.gone';
+					$notAvailable[$code] = 'gone';
 				}
 			}
 			else

--- a/lib/mshoplib/src/MShop/Plugin/Provider/Order/Coupon.php
+++ b/lib/mshoplib/src/MShop/Plugin/Provider/Order/Coupon.php
@@ -79,7 +79,14 @@ class Coupon
 			if( ( $couponItem = reset( $results ) ) !== false )
 			{
 				$couponProvider = $couponManager->getProvider( $couponItem, strtolower( $code ) );
-				$couponProvider->updateCoupon( $order );
+				try 
+				{
+					$couponProvider->updateCoupon( $order );
+				}
+				catch( \Exception $e )
+				{
+					$notAvailable[$code] = 'coupon.gone';
+				}
 			}
 			else
 			{

--- a/lib/mshoplib/tests/MShop/Coupon/Provider/FixedRebateTest.php
+++ b/lib/mshoplib/tests/MShop/Coupon/Provider/FixedRebateTest.php
@@ -222,7 +222,7 @@ class FixedRebateTest extends \PHPUnit\Framework\TestCase
 		$item = \Aimeos\MShop\Coupon\Manager\Factory::createManager( $context )->createItem();
 		$object = new \Aimeos\MShop\Coupon\Provider\FixedRebate( $context, $item, '5678' );
 
-		$this->setExpectedException( '\\Aimeos\\Plugin\\Provider\\Exception' );
+		$this->setExpectedException( '\\Aimeos\\MShop\\Plugin\\Provider\\Exception' );
 		$object->updateCoupon( $this->orderBase );
 	}
 

--- a/lib/mshoplib/tests/MShop/Coupon/Provider/FixedRebateTest.php
+++ b/lib/mshoplib/tests/MShop/Coupon/Provider/FixedRebateTest.php
@@ -216,6 +216,17 @@ class FixedRebateTest extends \PHPUnit\Framework\TestCase
 	}
 
 
+	public function testUpdateNotAvailable()
+	{
+		$context = \TestHelperMShop::getContext();
+		$item = \Aimeos\MShop\Coupon\Manager\Factory::createManager( $context )->createItem();
+		$object = new \Aimeos\MShop\Coupon\Provider\FixedRebate( $context, $item, '5678' );
+
+		$this->setExpectedException( '\\Aimeos\\Plugin\\Provider\\Exception' );
+		$object->updateCoupon( $this->orderBase );
+	}
+
+
 	protected function getOrderProducts()
 	{
 		$products = [];


### PR DESCRIPTION
Current behaviour: When an active coupon code becomes unavailable - e.g. because a price condition is not met anymore after a product was deleted from the basket -, the coupon just disappears without a notice. It is still stored (but invisible), so when the user tries to enter it again, he recieves a cryptic error message saying the maximum limit was reached.

This PR fixes the described behaviour: When a coupon becomes unavailable, an exception is thrown. Furthermore, the coupon code is entirely removed from the basket. This is way more intuitive IMO and is standard behaviour in major online shops like Amazon.

Last but not least, the coupon provider catches the exception and integrates it into other error messages regarding unavailable coupons.