### PR TITLE
Improve comparing products with multiple same-code attributes

### DIFF
--- a/lib/mshoplib/src/MShop/Order/Item/Base/Base.php
+++ b/lib/mshoplib/src/MShop/Order/Item/Base/Base.php
@@ -277,9 +277,9 @@ abstract class Base
 
 		$this->notifyListeners( 'editProduct.before', $item );
 
-		if( ( $origpos = $this->getSameProduct( $item, $this->products ) ) !== false )
+		if( ( $pos = $this->getSameProduct( $item, $this->products ) ) !== false )
 		{
-			$this->products[$origpos] = $item;
+			$this->products[$pos] = $item;
 			$this->setModified();
 		}
 		else

--- a/lib/mshoplib/src/MShop/Order/Item/Base/Base.php
+++ b/lib/mshoplib/src/MShop/Order/Item/Base/Base.php
@@ -673,9 +673,11 @@ abstract class Base
 	protected function getSameProduct( \Aimeos\MShop\Order\Item\Base\Product\Iface $item, array $products )
 	{
 		$attributeMap = [];
+		$attributeCount = 0;
 
 		foreach( $item->getAttributes() as $attributeItem ) {
-			$attributeMap[$attributeItem->getCode()] = $attributeItem;
+			$attributeMap[$attributeItem->getCode()][$attributeItem->getValue()] = $attributeItem;
+			$attributeCount++;
 		}
 
 		foreach( $products as $position => $product )
@@ -686,15 +688,14 @@ abstract class Base
 
 			$prodAttributes = $product->getAttributes();
 
-			if( count( $prodAttributes ) !== count( $attributeMap ) ) {
+			if( count( $prodAttributes ) !== $attributeCount ) {
 				continue;
 			}
 
 			foreach( $prodAttributes as $attribute )
 			{
-				if( array_key_exists( $attribute->getCode(), $attributeMap ) === false
-					|| $attributeMap[$attribute->getCode()]->getValue() != $attribute->getValue()
-					|| $attributeMap[$attribute->getCode()]->getQuantity() != $attribute->getQuantity()
+				if( isset( $attributeMap[$attribute->getCode()][$attribute->getValue()] ) === false
+					|| $attributeMap[$attribute->getCode()][$attribute->getValue()]->getQuantity() != $attribute->getQuantity()
 				) {
 					continue 2; // jump to outer loop
 				}

--- a/lib/mshoplib/src/MShop/Order/Item/Base/Base.php
+++ b/lib/mshoplib/src/MShop/Order/Item/Base/Base.php
@@ -277,9 +277,9 @@ abstract class Base
 
 		$this->notifyListeners( 'editProduct.before', $item );
 
-		if( ( $pos = $this->getSameProduct( $item, $this->products ) ) !== false )
+		if( ( $origpos = $this->getSameProduct( $item, $this->products ) ) !== false )
 		{
-			$this->products[$pos] = $item;
+			$this->products[$origpos] = $item;
 			$this->setModified();
 		}
 		else


### PR DESCRIPTION
Bugfix: Products can have multiple attributes with the same attribute code. In the map in L675 this was not considered, so these products would never get matched. Adding them to the basket would not increase the quantity, but rather add a second/third/... same basket item.

Note: This is 2018.x, I don't know if the same bug exists in 2019.x!