### PR TITLE
Fix wrong position bug in editProduct()

### DIFF
--- a/lib/mshoplib/src/MShop/Order/Item/Base/Base.php
+++ b/lib/mshoplib/src/MShop/Order/Item/Base/Base.php
@@ -277,9 +277,9 @@ abstract class Base
 
 		$this->notifyListeners( 'editProduct.before', $item );
 
-		if( ( $pos = $this->getSameProduct( $item, $this->products ) ) !== false )
+		if( ( $origpos = $this->getSameProduct( $item, $this->products ) ) !== false )
 		{
-			$this->products[$pos] = $item;
+			$this->products[$origpos] = $item;
 			$this->setModified();
 		}
 		else


### PR DESCRIPTION
Fixed a bug in `editProduct()` where the `$pos` variable was overwritten too early. If there is no matching product in the basket (don't know when this should occur, but it does together with the bug above), the edited item would get stored at position 0 (resulting from `return false`). This results in duplicated or overwritten basket items.