### PR TITLE
Add configuration option to progress delivery status automatically

### DIFF
--- a/lib/mshoplib/src/MShop/Service/Provider/Delivery/Manual.php
+++ b/lib/mshoplib/src/MShop/Service/Provider/Delivery/Manual.php
@@ -29,7 +29,18 @@ class Manual
 	 */
 	public function process( \Aimeos\MShop\Order\Item\Iface $order )
 	{
-		$order->setDeliveryStatus( \Aimeos\MShop\Order\Item\Base::STAT_PROGRESS );
+		/** mshop/service/provider/delivery/auto-status
+		 * Set delivery status to STAT_PROGRESS automatically when the
+		 * payment is confirmed (authorized or recieved status).
+		 *
+		 * @param bool Set delivery status automatically
+		 * @since 2018.10
+		 * @category Developer
+		 */
+		if( $this->getContext()->getConfig()->get( 'mshop/service/provider/delivery/auto-status', 1 ) )
+		{
+			$order->setDeliveryStatus( \Aimeos\MShop\Order\Item\Base::STAT_PROGRESS );
+		}
 	}
 
 }

--- a/lib/mshoplib/src/MShop/Service/Provider/Delivery/Standard.php
+++ b/lib/mshoplib/src/MShop/Service/Provider/Delivery/Standard.php
@@ -92,7 +92,18 @@ class Standard
 
 		$this->checkResponse( $response, $order->getId() );
 
-		$order->setDeliveryStatus( \Aimeos\MShop\Order\Item\Base::STAT_PROGRESS );
+		/** mshop/service/provider/delivery/auto-status
+		 * Set delivery status to STAT_PROGRESS automatically when the
+		 * payment is confirmed (authorized or recieved status).
+		 *
+		 * @param bool Set delivery status automatically
+		 * @since 2018.10
+		 * @category Developer
+		 */
+		if( $this->getContext()->getConfig()->get( 'mshop/service/provider/delivery/auto-status', 1 ) )
+		{
+			$order->setDeliveryStatus( \Aimeos\MShop\Order\Item\Base::STAT_PROGRESS );
+		}
 	}
 
 


### PR DESCRIPTION
Currently, the delivery status is changed to "in progress" as soon as the payment is recieved. I've added a configuration option to prevent this behaviour if a shop owner wants to control this process manually. What do you think?