### PR TITLE
Add dependencies to allow direct updates from 18.x to 19.10.x

### DIFF
--- a/lib/mshoplib/setup/AttributeMigrateKey.php
+++ b/lib/mshoplib/setup/AttributeMigrateKey.php
@@ -21,7 +21,7 @@ class AttributeMigrateKey extends \Aimeos\MW\Setup\Task\Base
 	 */
 	public function getPreDependencies()
 	{
-		return [];
+		return ['TypesMigrateColumns'];
 	}
 
 

--- a/lib/mshoplib/setup/TablesMigrateListsKey.php
+++ b/lib/mshoplib/setup/TablesMigrateListsKey.php
@@ -34,7 +34,7 @@ class TablesMigrateListsKey extends \Aimeos\MW\Setup\Task\Base
 	 */
 	public function getPreDependencies()
 	{
-		return [];
+		return ['TypesMigrateColumns'];
 	}
 
 

--- a/lib/mshoplib/setup/TablesMigratePropertyKey.php
+++ b/lib/mshoplib/setup/TablesMigratePropertyKey.php
@@ -30,7 +30,7 @@ class TablesMigratePropertyKey extends \Aimeos\MW\Setup\Task\Base
 	 */
 	public function getPreDependencies()
 	{
-		return [];
+		return ['TypesMigrateColumns'];
 	}
 
 


### PR DESCRIPTION
This patch ensures previous type migration before updating indizes having the type field included