### PR TITLE
Require the existence of function getInstalledPackagesByType

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
 	"minimum-stability": "dev",
 	"require": {
 		"php": "~7.1||^8.0.10",
+		"composer-runtime-api": "^2.1",
 		"ext-curl": "*",
 		"ext-dom": "*",
 		"ext-fileinfo": "*",


### PR DESCRIPTION
Hi!

We've run into an annoying bug after the update to Aimeos 2021.07, the extensions which have moved from ext/ to vendor/aimeos were correctly autoloaded by Composer but the other assets were not, because they were not discovered by Aimeos (in https://github.com/aimeos/aimeos-core/blob/master/Bootstrap.php#L33).

What happens is that if the composer version is too old (i.e. it doesn't satisfy the requirements of composer-runtime-api ^2.1), the class \Composer\InstalledVersions doesn't have a getInstalledPackagesByType() function and Aimeos extensions in the vendor/ directory are not loaded.

One way to warn users about that is to require composer-runtime-api ^2.1 to prevent updating Aimeos without a recent enough Composer (this is what this commit does), or maybe to polyfill getInstalledPackagesByType().

What do you guys think?