### PR TITLE
Fix missing VAT calculation with FreeShipping coupon

### DIFF
--- a/lib/mshoplib/src/MShop/Coupon/Provider/FreeShipping.php
+++ b/lib/mshoplib/src/MShop/Coupon/Provider/FreeShipping.php
@@ -81,7 +81,9 @@ class FreeShipping
 		foreach( $base->getService( \Aimeos\MShop\Order\Item\Base\Service\Base::TYPE_DELIVERY ) as $service )
 		{
 			$price = $price->setRebate( $price->getRebate() + $service->getPrice()->getCosts() )
-				->setCosts( $price->getCosts() - $service->getPrice()->getCosts() );
+				->setCosts( $price->getCosts() - $service->getPrice()->getCosts() )
+				->setTaxRates( $service->getPrice()->getTaxRates() )
+				->setModified();
 		}
 
 		$base->setCoupon( $this->getCode(), [$orderProduct->setPrice( $price )] );


### PR DESCRIPTION
VAT was not reduced with the FreeShipping coupon code leading to wrong tax values.