### PR TITLE
PayPalExpress shipping cost calculation bugfix and locale configuration

### DIFF
--- a/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
+++ b/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
@@ -160,6 +160,15 @@ class PayPalExpress
 			'default' => 'https://www.paypal.com/webscr&cmd=_notify-validate',
 			'required' => false,
 		),
+		'paypalexpress.LocaleCode' => array(
+			'code' => 'paypalexpress.LocaleCode',
+			'internalcode' => 'paypalexpress.LocaleCode',
+			'label' => 'Locale code',
+			'type' => 'string',
+			'internaltype' => 'string',
+			'default' => '',
+			'required' => false,
+		),
 	);
 
 
@@ -761,6 +770,10 @@ class PayPalExpress
 		$values['PAYMENTREQUEST_0_SHIPDISCAMT'] = '0.00';
 		$values['PAYMENTREQUEST_0_CURRENCYCODE'] = $orderBase->getPrice()->getCurrencyId();
 		$values['PAYMENTREQUEST_0_PAYMENTACTION'] = $this->getConfigValue( array( 'paypalexpress.PaymentAction' ), 'sale' );
+
+		if( $localecode = $this->getConfigValue( 'paypalexpress.LocaleCode', null ) ) {
+			$values['LOCALECODE'] = $localecode;
+		}
 
 		return $values;
 	}

--- a/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
+++ b/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
@@ -687,7 +687,7 @@ class PayPalExpress
 			}
 		}
 
-
+		$itemDeliveryCosts = 0;
 		if( $this->getConfigValue( 'paypalexpress.product', true ) )
 		{
 			foreach( $orderBase->getProducts() as $product )
@@ -702,6 +702,10 @@ class PayPalExpress
 				$values['L_PAYMENTREQUEST_0_NAME' . $lastPos] = $product->getName();
 				$values['L_PAYMENTREQUEST_0_QTY' . $lastPos] = $product->getQuantity();
 				$values['L_PAYMENTREQUEST_0_AMT' . $lastPos] = $this->getAmount( $price, false );
+			}
+			
+			foreach( $deliveryPrices as $priceItem ) {
+				$itemDeliveryCosts += $this->getAmount( $priceItem, true, true, 2 );
 			}
 		}
 
@@ -727,8 +731,8 @@ class PayPalExpress
 				foreach( $orderBase->getService( 'delivery' ) as $service )
 				{
 					$deliveryPrices = $this->addPrice( $deliveryPrices, $service->getPrice() );
-
-					$values['L_SHIPPINGOPTIONAMOUNT' . $lastPos] = number_format( $service->getPrice()->getCosts(), 2, '.', '' );
+					
+					$values['L_SHIPPINGOPTIONAMOUNT' . $lastPos] = number_format( $service->getPrice()->getCosts() + $itemDeliveryCosts, 2, '.', '' );
 					$values['L_SHIPPINGOPTIONLABEL' . $lastPos] = $service->getCode();
 					$values['L_SHIPPINGOPTIONNAME' . $lastPos] = $service->getName();
 					$values['L_SHIPPINGOPTIONISDEFAULT' . $lastPos] = 'true';


### PR DESCRIPTION
For the bugfix, see https://github.com/aimeos/aimeos-core/issues/269 - PayPalExpress service provider now adds all product related shipping costs to the shipping service costs.

Locale code configuration option allows to set a default language for the PayPal checkout landing page.