### PR TITLE
Add product related shipping costs to PayPalExpress payment service provider

### DIFF
--- a/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
+++ b/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
@@ -731,7 +731,7 @@ class PayPalExpress
 				foreach( $orderBase->getService( 'delivery' ) as $service )
 				{
 					$deliveryPrices = $this->addPrice( $deliveryPrices, $service->getPrice() );
-					
+
 					$values['L_SHIPPINGOPTIONAMOUNT' . $lastPos] = number_format( $service->getPrice()->getCosts() + $itemDeliveryCosts, 2, '.', '' );
 					$values['L_SHIPPINGOPTIONLABEL' . $lastPos] = $service->getCode();
 					$values['L_SHIPPINGOPTIONNAME' . $lastPos] = $service->getName();

--- a/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
+++ b/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
@@ -687,7 +687,7 @@ class PayPalExpress
 			}
 		}
 
-
+		$itemDeliveryCosts = 0;
 		if( $this->getConfigValue( 'paypalexpress.product', true ) )
 		{
 			foreach( $orderBase->getProducts() as $product )
@@ -702,6 +702,10 @@ class PayPalExpress
 				$values['L_PAYMENTREQUEST_0_NAME' . $lastPos] = $product->getName();
 				$values['L_PAYMENTREQUEST_0_QTY' . $lastPos] = $product->getQuantity();
 				$values['L_PAYMENTREQUEST_0_AMT' . $lastPos] = $this->getAmount( $price, false );
+			}
+			
+			foreach( $deliveryPrices as $priceItem ) {
+				$itemDeliveryCosts += $this->getAmount( $priceItem, true, true, 2 );
 			}
 		}
 
@@ -727,8 +731,8 @@ class PayPalExpress
 				foreach( $orderBase->getService( 'delivery' ) as $service )
 				{
 					$deliveryPrices = $this->addPrice( $deliveryPrices, $service->getPrice() );
-
-					$values['L_SHIPPINGOPTIONAMOUNT' . $lastPos] = number_format( $service->getPrice()->getCosts(), 2, '.', '' );
+					
+					$values['L_SHIPPINGOPTIONAMOUNT' . $lastPos] = number_format( $service->getPrice()->getCosts() + $itemDeliveryCosts, 2, '.', '' );
 					$values['L_SHIPPINGOPTIONLABEL' . $lastPos] = $service->getCode();
 					$values['L_SHIPPINGOPTIONNAME' . $lastPos] = $service->getName();
 					$values['L_SHIPPINGOPTIONISDEFAULT' . $lastPos] = 'true';


### PR DESCRIPTION
For the bugfix, see #269 - PayPalExpress service provider now adds all product related shipping costs to the shipping service costs.