### PR TITLE
PayPalExpress payment provider: Locale configuration

### DIFF
--- a/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
+++ b/lib/mshoplib/src/MShop/Service/Provider/Payment/PayPalExpress.php
@@ -160,6 +160,15 @@ class PayPalExpress
 			'default' => 'https://www.paypal.com/webscr&cmd=_notify-validate',
 			'required' => false,
 		),
+		'paypalexpress.LocaleCode' => array(
+			'code' => 'paypalexpress.LocaleCode',
+			'internalcode' => 'paypalexpress.LocaleCode',
+			'label' => 'Locale code',
+			'type' => 'string',
+			'internaltype' => 'string',
+			'default' => '',
+			'required' => false,
+		),
 	);
 
 
@@ -761,6 +770,10 @@ class PayPalExpress
 		$values['PAYMENTREQUEST_0_SHIPDISCAMT'] = '0.00';
 		$values['PAYMENTREQUEST_0_CURRENCYCODE'] = $orderBase->getPrice()->getCurrencyId();
 		$values['PAYMENTREQUEST_0_PAYMENTACTION'] = $this->getConfigValue( array( 'paypalexpress.PaymentAction' ), 'sale' );
+
+		if( $localecode = $this->getConfigValue( 'paypalexpress.LocaleCode', null ) ) {
+			$values['LOCALECODE'] = $localecode;
+		}
 
 		return $values;
 	}

--- a/lib/mshoplib/tests/MShop/Service/Provider/Payment/PayPalExpressTest.php
+++ b/lib/mshoplib/tests/MShop/Service/Provider/Payment/PayPalExpressTest.php
@@ -78,7 +78,7 @@ class PayPalExpressTest extends \PHPUnit\Framework\TestCase
 	{
 		$result = $this->object->getConfigBE();
 
-		$this->assertEquals( 15, count( $result ) );
+		$this->assertEquals( 16, count( $result ) );
 
 		foreach( $result as $key => $item ) {
 			$this->assertInstanceOf( 'Aimeos\MW\Criteria\Attribute\Iface', $item );
@@ -99,7 +99,7 @@ class PayPalExpressTest extends \PHPUnit\Framework\TestCase
 
 		$result = $this->object->checkConfigBE( $attributes );
 
-		$this->assertEquals( 15, count( $result ) );
+		$this->assertEquals( 16, count( $result ) );
 		$this->assertEquals( null, $result['paypalexpress.ApiUsername'] );
 		$this->assertEquals( null, $result['paypalexpress.AccountEmail'] );
 		$this->assertEquals( null, $result['paypalexpress.ApiPassword'] );


### PR DESCRIPTION
Locale code configuration option allows to set a default language for the PayPal checkout landing page.