### PR TITLE
Register order plugins earlier when loading an order

### DIFF
--- a/lib/mshoplib/setup/unittest/data/coupon.php
+++ b/lib/mshoplib/setup/unittest/data/coupon.php
@@ -8,7 +8,14 @@
 return [
 	'coupon' => [[
 		'coupon.label' => 'Unit test fixed rebate', 'coupon.provider' => 'FixedRebate,Basket',
-		'coupon.config' => ['fixedrebate.productcode' => 'U:MD', 'basket.total-value-min' => ['EUR' => '9.00'], 'fixedrebate.rebate' => '2.50'],
+		'coupon.config' => ['fixedrebate.productcode' => 'U:MD', 'basket.total-value-min' => ['EUR' => '9.00'], 'fixedrebate.rebate' => ['EUR' => '2.50']],
+		'coupon.datestart' => '2002-01-01 00:00:00', 'coupon.dateend' => '2100-12-31 00:00:00',
+		'codes' => [[
+			'coupon.code.code' => '1234', 'coupon.code.count' => 2000000
+		]]
+	], [
+		'coupon.label' => 'Unit test fixed rebate (unavailable)', 'coupon.provider' => 'FixedRebate,Basket',
+		'coupon.config' => ['fixedrebate.productcode' => 'U:MD', 'basket.total-value-min' => ['EUR' => '9.00'], 'fixedrebate.rebate' => ['EUR' => '2.50']],
 		'coupon.datestart' => '2002-01-01 00:00:00', 'coupon.dateend' => '2100-12-31 00:00:00',
 		'codes' => [[
 			'coupon.code.code' => '5678', 'coupon.code.count' => 2000000,

--- a/lib/mshoplib/setup/unittest/data/order.php
+++ b/lib/mshoplib/setup/unittest/data/order.php
@@ -83,9 +83,11 @@ return array(
 
 	//ordprodid => prodcode/quantity/pos
 	'order/base/coupon' => [
-		['baseid' => '53.50', 'ordprodid' => 'U:MD/1/3', 'code' => '5678'],
+		['baseid' => '53.50', 'ordprodid' => 'U:MD/1/3', 'code' => '1234'],
+		//['baseid' => '53.50', 'ordprodid' => 'U:MD/1/3', 'code' => '5678'], 
 		['baseid' => '53.50', 'ordprodid' => 'ABCD/1/4', 'code' => 'OPQR'],
 		['baseid' => '672.00', 'ordprodid' => 'CNE/2/1', 'code' => '5678'],
+		//['baseid' => '672.00', 'ordprodid' => 'CNE/2/1', 'code' => '90AB'],
 		['baseid' => '672.00', 'ordprodid' => 'CNC/1/2', 'code' => 'OPQR'],
 	],
 

--- a/lib/mshoplib/setup/unittest/data/order.php
+++ b/lib/mshoplib/setup/unittest/data/order.php
@@ -84,10 +84,8 @@ return array(
 	//ordprodid => prodcode/quantity/pos
 	'order/base/coupon' => [
 		['baseid' => '53.50', 'ordprodid' => 'U:MD/1/3', 'code' => '1234'],
-		//['baseid' => '53.50', 'ordprodid' => 'U:MD/1/3', 'code' => '5678'], 
 		['baseid' => '53.50', 'ordprodid' => 'ABCD/1/4', 'code' => 'OPQR'],
 		['baseid' => '672.00', 'ordprodid' => 'CNE/2/1', 'code' => '5678'],
-		//['baseid' => '672.00', 'ordprodid' => 'CNE/2/1', 'code' => '90AB'],
 		['baseid' => '672.00', 'ordprodid' => 'CNC/1/2', 'code' => 'OPQR'],
 	],
 

--- a/lib/mshoplib/setup/unittest/data/plugin.php
+++ b/lib/mshoplib/setup/unittest/data/plugin.php
@@ -13,7 +13,7 @@ return [
 
 	'plugin' => [[
 		'plugin.type' => 'order', 'plugin.label' => 'Shipping-Plugin', 'plugin.provider' => 'Shipping,Example',
-		'plugin.config' => ["threshold" => ["EUR" =>"34.00"]], 'plugin.status' => 1
+		'plugin.config' => ["threshold" => ["EUR" =>"500.00"]], 'plugin.status' => 1
 	], [
 		'plugin.type' => 'order', 'plugin.label' => 'ProductLimit-Plugin', 'plugin.provider' => 'ProductLimit,Example',
 		'plugin.config' => ["single-number-max" => "10"], 'plugin.status' => 1

--- a/lib/mshoplib/src/MShop/Order/Manager/Base/Base.php
+++ b/lib/mshoplib/src/MShop/Order/Manager/Base/Base.php
@@ -465,16 +465,16 @@ abstract class Base
 			}
 		}
 
-		foreach( $coupons as $code => $items ) {
-			$basket->addCoupon( $code );
-		}
-
 		foreach( $addresses as $item ) {
 			$basket->addAddress( $item, $item->getType() );
 		}
 
 		foreach( $services as $item ) {
 			$basket->addService( $item, $item->getType() );
+		}
+
+		foreach( $coupons as $code => $items ) {
+			$basket->addCoupon( $code );
 		}
 
 		return $basket;

--- a/lib/mshoplib/src/MShop/Order/Manager/Base/Base.php
+++ b/lib/mshoplib/src/MShop/Order/Manager/Base/Base.php
@@ -413,6 +413,8 @@ abstract class Base
 
 		$basket = $this->createItemBase( $price, $localeItem, $row, $products, $addresses, $services, $coupons );
 
+		\Aimeos\MShop::create( $this->getContext(), 'plugin' )->register( $basket, 'order' );
+
 		return $basket;
 	}
 
@@ -453,6 +455,8 @@ abstract class Base
 
 		$basket = $this->createItemBase( $price, $localeItem, $row );
 		$basket->setId( null );
+
+		\Aimeos\MShop::create( $this->getContext(), 'plugin' )->register( $basket, 'order' );
 
 		foreach( $products as $item )
 		{

--- a/lib/mshoplib/src/MShop/Order/Manager/Base/Standard.php
+++ b/lib/mshoplib/src/MShop/Order/Manager/Base/Standard.php
@@ -1022,9 +1022,6 @@ class Standard extends Base
 			$basket = $this->loadFresh( $id, $price, $localeItem, $row, $parts );
 		}
 
-		$pluginManager = \Aimeos\MShop::create( $this->getContext(), 'plugin' );
-		$pluginManager->register( $basket, 'order' );
-
 		return $basket;
 	}
 

--- a/lib/mshoplib/tests/MShop/Coupon/Manager/Code/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Coupon/Manager/Code/StandardTest.php
@@ -203,7 +203,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$result = $this->object->search( $search, [], $total )->toArray();
 
 		$this->assertEquals( 1, count( $result ) );
-		$this->assertEquals( 5, $total );
+		$this->assertEquals( 6, $total );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Coupon/Manager/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Coupon/Manager/StandardTest.php
@@ -197,7 +197,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$expr = [];
 		$expr[] = $search->compare( '!=', 'coupon.id', null );
 		$expr[] = $search->compare( '!=', 'coupon.siteid', null );
-		$expr[] = $search->compare( '==', 'coupon.label', 'Unit test fixed rebate' );
+		$expr[] = $search->compare( '==', 'coupon.label', 'Unit test fixed rebate (unavailable)' );
 		$expr[] = $search->compare( '=~', 'coupon.provider', 'FixedRebate' );
 		$expr[] = $search->compare( '~=', 'coupon.config', 'product' );
 		$expr[] = $search->compare( '==', 'coupon.datestart', '2002-01-01 00:00:00' );
@@ -241,6 +241,6 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$result = $this->object->search( $search, [], $total )->toArray();
 
 		$this->assertEquals( 1, count( $result ) );
-		$this->assertEquals( 6, $total );
+		$this->assertEquals( 7, $total );
 	}
 }

--- a/lib/mshoplib/tests/MShop/Coupon/Provider/VoucherTest.php
+++ b/lib/mshoplib/tests/MShop/Coupon/Provider/VoucherTest.php
@@ -122,7 +122,7 @@ class VoucherTest extends \PHPUnit\Framework\TestCase
 
 	public function testGetUsedRebate()
 	{
-		$rebate = $this->access( 'getUsedRebate' )->invokeArgs( $this->object, ['5678'] );
+		$rebate = $this->access( 'getUsedRebate' )->invokeArgs( $this->object, ['1234'] );
 
 		$this->assertEquals( 5.0, $rebate );
 	}

--- a/lib/mshoplib/tests/MShop/Order/Manager/Base/Coupon/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Order/Manager/Base/Coupon/StandardTest.php
@@ -35,9 +35,9 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$search->setConditions( $search->compare( '==', 'order.base.coupon.editor', 'core:lib/mshoplib' ) );
 		$result = $this->object->aggregate( $search, 'order.base.coupon.code' )->toArray();
 
-		$this->assertEquals( 2, count( $result ) );
-		$this->assertArrayHasKey( '5678', $result );
-		$this->assertEquals( 2, $result['5678'] );
+		$this->assertEquals( 3, count( $result ) );
+		$this->assertArrayHasKey( 'OPQR', $result );
+		$this->assertEquals( 2, $result['OPQR'] );
 	}
 
 
@@ -113,7 +113,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$results = $this->object->search( $search, [], $total )->toArray();
 
 		$this->assertEquals( 1, count( $results ) );
-		$this->assertGreaterThanOrEqual( 4, $total );
+		$this->assertGreaterThanOrEqual( 3, $total );
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
@@ -654,10 +654,13 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 		$pos = 0;
 		$products = $basket->getProducts();
-		$this->assertEquals( 2, count( $products ) );
+		$this->assertEquals( 3, count( $products ) );
 
 		foreach( $products as $product )
 		{
+			if( $product->getProductCode() == 'U:MD' ) {
+				continue;
+			}
 			$this->assertGreaterThanOrEqual( 2, count( $product->getAttributeItems() ) );
 			$this->assertEquals( $pos++, $product->getPosition() );
 		}
@@ -863,7 +866,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 		$this->assertEquals( '52.50', $newBasket->getPrice()->getValue() );
 		$this->assertEquals( '1.50', $newBasket->getPrice()->getCosts() );
-		$this->assertEquals( '6.00', $newBasket->getPrice()->getRebate() );
+		$this->assertEquals( '11.00', $newBasket->getPrice()->getRebate() );
 		$this->assertEquals( 2, count( $newBasket->getCoupons() ) );
 	}
 

--- a/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
@@ -691,13 +691,13 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$item = $this->getOrderItem();
 
 		$basket = $this->object->load( $item->getId(), \Aimeos\MShop\Order\Item\Base\Base::PARTS_ALL, true );
-
 		$this->object->store( $basket );
 		$newBasketId = $basket->getId();
 		$this->object->store( $basket );
 		$newBasket = $this->object->load( $newBasketId );
 
 		$this->object->delete( $newBasketId );
+
 
 		$newAddresses = $newBasket->getAddresses();
 
@@ -708,9 +708,12 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 			}
 		}
 
-		$newProducts = $newBasket->getProducts();
-		foreach( $basket->getProducts() as $key => $product ) {
-			$this->assertEquals( $product->getId(), $newProducts[$key]->getId() );
+		// streamline keys in fresh loaded order, see https://github.com/aimeos/aimeos-core/pull/280
+		$products = $basket->getProducts();
+		$productsKeys = $products->keys();
+
+		foreach( $newBasket->getProducts() as $key => $product ) {
+			$this->assertEquals( $product->getId(), $products[$productsKeys[$key]]->getId() );
 		}
 
 		$newServices = $newBasket->getServices();

--- a/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
@@ -698,32 +698,18 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 		$this->object->delete( $newBasketId );
 
-
-		$newAddresses = $newBasket->getAddresses();
-
-		foreach( $basket->getAddresses() as $key => $list )
+		foreach( $basket->getAddresses() as $type => $list )
 		{
-			foreach( $list as $pos => $address ) {
-				$this->assertEquals( $address->getId(), $newAddresses[$key][$pos]->getId() );
-			}
+			$this->assertTrue( map( $list )->getId()->equals( map( $newBasket->getAddress( $type ) )->getId() ) );
 		}
 
-		// streamline keys in fresh loaded order, see https://github.com/aimeos/aimeos-core/pull/280
-		$products = $basket->getProducts();
-		$productsKeys = $products->keys();
+		$this->assertTrue( $basket->getProducts()->getId()->equals( $newBasket->getProducts()->getId() ) );
 
-		foreach( $newBasket->getProducts() as $key => $product ) {
-			$this->assertEquals( $product->getId(), $products[$productsKeys[$key]]->getId() );
-		}
-
-		$newServices = $newBasket->getServices();
-
-		foreach( $basket->getServices() as $key => $list )
+		foreach( $basket->getServices() as $type => $list )
 		{
-			foreach( $list as $pos => $service ) {
-				$this->assertEquals( $service->getId(), $newServices[$key][$pos]->getId() );
-			}
+			$this->assertTrue( map( $list )->getId()->equals( map( $newBasket->getService( $type ) )->getId() ) );
 		}
+
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
@@ -39,8 +39,8 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$result = $this->object->aggregate( $search, 'order.base.rebate' )->toArray();
 
 		$this->assertEquals( 3, count( $result ) );
-		$this->assertArrayHasKey( '5.00', $result );
-		$this->assertEquals( 2, $result['5.00'] );
+		$this->assertArrayHasKey( '4.50', $result );
+		$this->assertEquals( 1, $result['4.50'] );
 	}
 
 
@@ -126,7 +126,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 
 		$search = $this->object->filter();
 		$conditions = array(
-			$search->compare( '==', 'order.base.costs', '1.50' ),
+			$search->compare( '==', 'order.base.costs', '6.50' ),
 			$search->compare( '==', 'order.base.editor', $this->editor )
 		);
 		$search->setConditions( $search->and( $conditions ) );
@@ -244,8 +244,8 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$expr[] = $search->compare( '==', 'order.base.languageid', 'de' );
 		$expr[] = $search->compare( '==', 'order.base.currencyid', 'EUR' );
 		$expr[] = $search->compare( '==', 'order.base.price', '53.50' );
-		$expr[] = $search->compare( '==', 'order.base.costs', '1.50' );
-		$expr[] = $search->compare( '==', 'order.base.rebate', '14.50' );
+		$expr[] = $search->compare( '==', 'order.base.costs', '6.50' );
+		$expr[] = $search->compare( '==', 'order.base.rebate', '9.50' );
 		$expr[] = $search->compare( '==', 'order.base.taxvalue', '0.0000' );
 		$expr[] = $search->compare( '~=', 'order.base.customerref', 'ABC-1234' );
 		$expr[] = $search->compare( '~=', 'order.base.comment', 'This is a comment' );
@@ -688,13 +688,13 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$item = $this->getOrderItem();
 
 		$basket = $this->object->load( $item->getId(), \Aimeos\MShop\Order\Item\Base\Base::PARTS_ALL, true );
+
 		$this->object->store( $basket );
 		$newBasketId = $basket->getId();
 		$this->object->store( $basket );
 		$newBasket = $this->object->load( $newBasketId );
 
 		$this->object->delete( $newBasketId );
-
 
 		$newAddresses = $newBasket->getAddresses();
 
@@ -706,7 +706,6 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		}
 
 		$newProducts = $newBasket->getProducts();
-
 		foreach( $basket->getProducts() as $key => $product ) {
 			$this->assertEquals( $product->getId(), $newProducts[$key]->getId() );
 		}
@@ -880,7 +879,7 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$search = $this->object->filter();
 
 		$expr = [];
-		$expr[] = $search->compare( '==', 'order.base.rebate', 14.50 );
+		$expr[] = $search->compare( '==', 'order.base.rebate', 9.50 );
 		$expr[] = $search->compare( '==', 'order.base.sitecode', 'unittest' );
 		$expr[] = $search->compare( '==', 'order.base.price', 53.50 );
 		$expr[] = $search->compare( '==', 'order.base.editor', $this->editor );

--- a/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Order/Manager/Base/StandardTest.php
@@ -709,7 +709,6 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		{
 			$this->assertTrue( map( $list )->getId()->equals( map( $newBasket->getService( $type ) )->getId() ) );
 		}
-
 	}
 
 

--- a/lib/mshoplib/tests/MShop/Order/Manager/StandardTest.php
+++ b/lib/mshoplib/tests/MShop/Order/Manager/StandardTest.php
@@ -414,8 +414,8 @@ class StandardTest extends \PHPUnit\Framework\TestCase
 		$expr[] = $search->compare( '==', 'order.base.languageid', 'de' );
 		$expr[] = $search->compare( '==', 'order.base.currencyid', 'EUR' );
 		$expr[] = $search->compare( '==', 'order.base.price', '53.50' );
-		$expr[] = $search->compare( '==', 'order.base.costs', '1.50' );
-		$expr[] = $search->compare( '==', 'order.base.rebate', '14.50' );
+		$expr[] = $search->compare( '==', 'order.base.costs', '6.50' );
+		$expr[] = $search->compare( '==', 'order.base.rebate', '9.50' );
 		$expr[] = $search->compare( '~=', 'order.base.comment', 'This is a comment' );
 		$expr[] = $search->compare( '>=', 'order.base.mtime', '1970-01-01 00:00:00' );
 		$expr[] = $search->compare( '>=', 'order.base.ctime', '1970-01-01 00:00:00' );


### PR DESCRIPTION
When loading an order with the order base manager as a fresh order, the order elements (address, products, services, coupons) are added successively. However, the order plugins are not registered yet. Because of this behaviour, coupons are not added properly, as the coupon item is not added and therefore the rebate is not considered in the basket. Other plugins cannot provide their functionality, too, eg. address based order manipulation etc.