### PR TITLE
Allow enshrined/svg-sanitize in higher minor version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
 		"doctrine/dbal": "~2.0",
 		"psr/http-message": "~1.0",
 		"voku/portable-ascii": "^1.4",
-		"enshrined/svg-sanitize": "^0.14"
+		"enshrined/svg-sanitize": "~0.15"
 	},
 	"require-dev": {
 		"php-coveralls/php-coveralls": "~2.0",


### PR DESCRIPTION
This requires the ~ operator since ^ does not allow breaking changes and
those may be introduced in minor updates for versions < 1.0 as per
semver.

Also require 0.15+ due to https://github.com/advisories/GHSA-fqx8-v33p-4qcc

Basically this would allow versions <1.0.0, including breaking versions,
but that seems ok in this case.