### PR TITLE
Fixed a typo in the MShop/Media/Manager/Standard.php

### DIFF
--- a/src/MShop/Media/Manager/Standard.php
+++ b/src/MShop/Media/Manager/Standard.php
@@ -1105,7 +1105,7 @@ class Standard
 		{
 			$force = $entry['force-size'] ?? 0;
 			$maxwidth = $entry['maxwidth'] ?? null;
-			$maxheight = $entry['maxwidth'] ?? null;
+			$maxheight = $entry['maxheight'] ?? null;
 
 			if( $this->call( 'filterPreviews', $media, $domain, $type, $maxwidth, $maxheight, $force ) )
 			{


### PR DESCRIPTION
maxheight value is mistakenly taken from maxwidth