### PR TITLE
Add mimetypes for audio (mp3, ogg, weba) and epub

### DIFF
--- a/config/controller.php
+++ b/config/controller.php
@@ -18,6 +18,7 @@ return [
 				'application/vnd.oasis.opendocument.presentation' => 'odp',
 				'application/vnd.oasis.opendocument.spreadsheet' => 'ods',
 				'application/vnd.oasis.opendocument.text' => 'odt',
+				'application/epub+zip' => 'epub',
 				'application/x-gzip' => 'gz',
 				'application/zip' => 'zip',
 				'image/bmp' => 'bmp',
@@ -30,6 +31,10 @@ return [
 				'text/csv' => 'csv',
 				'video/mp4' => 'mp4',
 				'video/webm' => 'webm',
+				'audio/mpeg' => 'mpeg',
+				'audio/ogg' => 'ogg',
+				'audio/ogg' => 'ogg',
+				'audio/webm' => 'weba',
 			],
 			'previews' => [[
 				'force-size' => 0,

--- a/src/Controller/Common/Media/Standard.php
+++ b/src/Controller/Common/Media/Standard.php
@@ -599,8 +599,9 @@ class Standard
 		 */
 		$default = [
 			'image/webp', 'image/jpeg', 'image/png', 'image/gif', 'image/svg+xml',
-			'application/pdf', 'application/zip',
-			'video/mp4', 'video/webm'
+			'application/epub+zip', 'application/pdf', 'application/zip',
+			'video/mp4', 'video/webm',
+			'audio/mpeg', 'audio/ogg', 'audio/weba'
 		];
 		$allowed = $config->get( 'controller/common/media/' . $type . '/allowedtypes', $default );
 

--- a/src/MShop/Media/Manager/Standard.php
+++ b/src/MShop/Media/Manager/Standard.php
@@ -1311,8 +1311,9 @@ class Standard
 		 */
 		$default = [
 			'image/webp', 'image/jpeg', 'image/png', 'image/gif', 'image/svg+xml',
-			'application/pdf', 'application/zip',
-			'video/mp4', 'video/webm'
+			'application/epub+zip', 'application/pdf', 'application/zip',
+			'video/mp4', 'video/webm',
+			'audio/mpeg', 'audio/ogg', 'audio/weba'
 		];
 		$allowed = $config->get( 'controller/common/media/preview/allowedtypes', $default );
 


### PR DESCRIPTION
Required for allowing an audio display (audio player) in the media fields of ai-admin-jqadmin.