### PR TITLE
Qoute reserved keyword in migration

### DIFF
--- a/setup/ProductMigrateCatalog.php
+++ b/setup/ProductMigrateCatalog.php
@@ -30,7 +30,7 @@ class ProductMigrateCatalog extends Base
 
 		$insert = $db->stmt()->insert( 'mshop_product_list' )->values( [
 			'parentid' => '?', 'siteid' => '?', $db->qi( 'key' ) => '?', 'domain' => '?', 'type' => '?',
-			'start' => '?', 'end' => '?', 'config' => '?', 'status' => '?', 'pos' => '?',
+			'start' => '?', $db->qi('end') => '?', 'config' => '?', 'status' => '?', 'pos' => '?',
 			'refid' => '?', 'ctime' => '?', 'mtime' => '?', 'editor' => '?'
 		] );
 

--- a/setup/ProductMigrateSupplier.php
+++ b/setup/ProductMigrateSupplier.php
@@ -30,7 +30,7 @@ class ProductMigrateSupplier extends Base
 
 		$insert = $db->stmt()->insert( 'mshop_product_list' )->values( [
 			'parentid' => '?', 'siteid' => '?', $db->qi( 'key' ) => '?', 'domain' => '?', 'type' => '?',
-			'start' => '?', 'end' => '?', 'config' => '?', 'status' => '?', 'pos' => '?',
+			'start' => '?', $db->qi('end') => '?', 'config' => '?', 'status' => '?', 'pos' => '?',
 			'refid' => '?', 'ctime' => '?', 'mtime' => '?', 'editor' => '?'
 		] );
 


### PR DESCRIPTION
### Bug
Some migrations were failing, caomplaining about syntax errors in the sql queries.

### Problem
The queries were broken in postgresql since they used a column named `end` without qouting it, causing problems since `end` is a reserved keyword in postgresql.

### Fix
Use the `$db-qi(...)` for those columns.