### PR TITLE
[BUGFIX] Avoid passing null to json_decode

### DIFF
--- a/src/MShop/Common/Manager/Type/Base.php
+++ b/src/MShop/Common/Manager/Type/Base.php
@@ -218,7 +218,7 @@ abstract class Base
 
 		while( $row = $results->fetch() )
 		{
-			if( ( $row[$this->prefix . 'i18n'] = json_decode( $i18n = $row[$this->prefix . 'i18n'], true ) ) === null ) {
+			if( ( $row[$this->prefix . 'i18n'] = json_decode( ($i18n = $row[$this->prefix . 'i18n'] ?? ''), true ) ) === null ) {
 				$row[$this->prefix . 'i18n'] = [];
 			}
 


### PR DESCRIPTION
In a TYPO3 setup, this can trigger a deprecation error.
I ran `php ./vendor/bin/typo3 aimeos:setup` to test if the database fields for i18n changed, but they still have `null` as standard.